### PR TITLE
Add type checker for Python examples

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,2 @@
+# Files and directories to ignore during code generation
+examples/

--- a/.github/workflows/examples_build.yml
+++ b/.github/workflows/examples_build.yml
@@ -1,0 +1,31 @@
+name: Examples Build
+
+on:
+  pull_request:
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        
+    - uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+        
+    - uses: actions/cache@v3
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+        
+    - name: Install dependencies
+      run: poetry install
+      
+    - name: Type check examples directory
+      run: poetry run mypy examples/ --config-file examples/mypy.ini

--- a/examples/example_cloud_worker_group.py
+++ b/examples/example_cloud_worker_group.py
@@ -21,7 +21,7 @@ file configuration to run.
 """
 
 import asyncio
-from cribl_control_plane.models import ConfigGroup, ConfigGroupCloud
+from cribl_control_plane.models import ConfigGroup, ConfigGroupCloud, CloudProvider
 from auth import AuthCloud, CloudConfiguration
 
 
@@ -36,7 +36,7 @@ group = ConfigGroup(
     on_prem=False,
     worker_remote_access=True,
     cloud=ConfigGroupCloud(
-        provider="aws",
+        provider=CloudProvider.AWS,
         region="us-east-1"
     ),
     provisioned=False,

--- a/examples/example_edge.py
+++ b/examples/example_edge.py
@@ -26,11 +26,16 @@ import asyncio
 from cribl_control_plane.models import (
     ConfigGroup,
     InputSyslogSyslog2,
+    InputSyslogType2,
     OutputS3,
+    OutputS3Type,
+    OutputS3Compression,
+    OutputS3CompressionLevel,
     Pipeline,
     RoutesRoute,
     Conf,
     PipelineFunctionConf,
+    FunctionSpecificConfigs,
     InputSyslogTLSSettingsServerSide2
 )
 from auth import base_url, create_cribl_client
@@ -58,20 +63,20 @@ my_fleet = ConfigGroup(
 
 syslog_source = InputSyslogSyslog2(
     id="my-syslog-source",
-    type="syslog",
+    type=InputSyslogType2.SYSLOG,
     tcp_port=SYSLOG_PORT,
     tls=InputSyslogTLSSettingsServerSide2(disabled=True)
 )
 
 s3_destination = OutputS3(
     id="my-s3-destination",
-    type="s3",
+    type=OutputS3Type.S3,
     bucket=AWS_BUCKET_NAME,
     region=AWS_REGION,
     aws_secret_key=AWS_SECRET_KEY,
     aws_api_key=AWS_API_KEY,
-    compress="gzip",
-    compression_level="best_speed",
+    compress=OutputS3Compression.GZIP,
+    compression_level=OutputS3CompressionLevel.BEST_SPEED,
     empty_dir_cleanup_sec=300
 )
 
@@ -82,11 +87,11 @@ pipeline = Pipeline(
         async_func_timeout=1000,
         functions=[
             PipelineFunctionConf(
-                filter="true",
-                conf={
+                filter_="true",
+                conf=FunctionSpecificConfigs.model_validate({  # type: ignore
                     "remove": ["*"],
                     "keep": ["eventSource", "eventID"]
-                },
+                }),
                 id="eval",
                 final=True
             )

--- a/examples/example_packs.py
+++ b/examples/example_packs.py
@@ -25,11 +25,17 @@ Prerequisites:
 import asyncio
 from cribl_control_plane.models import (
     InputTcpjson,
+    InputTcpjsonType,
+    InputTcpjsonAuthenticationMethod,
     OutputS3,
+    OutputS3Type,
+    OutputS3Compression,
+    OutputS3CompressionLevel,
     Pipeline,
     RoutesRoute,
     Conf,
-    PipelineFunctionConf
+    PipelineFunctionConf,
+    FunctionSpecificConfigs
 )
 from auth import base_url, create_cribl_client
 
@@ -58,22 +64,22 @@ pack_url = f"{group_url}/p/{PACK_ID}"
 # TCP JSON source configuration
 tcp_json_source = InputTcpjson(
     id="my-tcp-json",
-    type="tcpjson",
+    type=InputTcpjsonType.TCPJSON,
     port=PORT,
-    auth_type="manual",
+    auth_type=InputTcpjsonAuthenticationMethod.MANUAL,
     auth_token=AUTH_TOKEN
 )
 
 # Amazon S3 destination configuration
 s3_destination = OutputS3(
     id="my-s3-destination",
-    type="s3",
+    type=OutputS3Type.S3,
     bucket=AWS_BUCKET_NAME,
     region=AWS_REGION,
     aws_secret_key=AWS_SECRET_KEY,
     aws_api_key=AWS_API_KEY,
-    compress="gzip",
-    compression_level="best_speed",
+    compress=OutputS3Compression.GZIP,
+    compression_level=OutputS3CompressionLevel.BEST_SPEED,
     empty_dir_cleanup_sec=300
 )
 
@@ -84,11 +90,11 @@ pipeline = Pipeline(
         async_func_timeout=1000,
         functions=[
             PipelineFunctionConf(
-                filter="true",
-                conf={
+                filter_="true",
+                conf=FunctionSpecificConfigs.model_validate({  # type: ignore
                     "remove": ["*"],
                     "keep": ["name"]
-                },
+                }),
                 id="eval",
                 final=True
             )

--- a/examples/example_stream.py
+++ b/examples/example_stream.py
@@ -25,11 +25,15 @@ import asyncio
 from cribl_control_plane.models import (
     ConfigGroup,
     InputTcpjson,
+    InputTcpjsonType,
+    InputTcpjsonAuthenticationMethod,
     OutputFilesystem,
+    OutputFilesystemType,
     Pipeline,
     RoutesRoute,
     Conf,
-    PipelineFunctionConf
+    PipelineFunctionConf,
+    FunctionSpecificConfigs
 )
 from auth import base_url, create_cribl_client
 
@@ -46,15 +50,15 @@ my_worker_group = ConfigGroup(
 
 tcp_json_source = InputTcpjson(
     id="my-tcp-json",
-    type="tcpjson",
+    type=InputTcpjsonType.TCPJSON,
     port=PORT,
-    auth_type="manual",
+    auth_type=InputTcpjsonAuthenticationMethod.MANUAL,
     auth_token=AUTH_TOKEN
 )
 
 file_system_destination = OutputFilesystem(
     id="my-fs-destination",
-    type="filesystem",
+    type=OutputFilesystemType.FILESYSTEM,
     dest_path="/tmp/my-output"
 )
 
@@ -65,11 +69,11 @@ pipeline = Pipeline(
         async_func_timeout=1000,
         functions=[
             PipelineFunctionConf(
-                filter="true",
-                conf={
+                filter_="true",
+                conf=FunctionSpecificConfigs.model_validate({  # type: ignore
                     "remove": ["*"],
                     "keep": ["name"]
-                },
+                }),
                 id="eval",
                 final=True
             )

--- a/examples/mypy.ini
+++ b/examples/mypy.ini
@@ -1,0 +1,38 @@
+[mypy]
+# Configuration for type checking extracted examples
+python_version = 3.9
+warn_return_any = False
+warn_unused_configs = True
+disallow_untyped_defs = False
+ignore_missing_imports = True
+no_strict_optional = True
+show_error_codes = True
+pretty = True
+
+# Allow incomplete examples
+allow_redefinition = True
+allow_untyped_globals = True
+allow_untyped_calls = True
+
+# Disable some strict checks for examples
+check_untyped_defs = False
+disallow_any_generics = False
+disallow_incomplete_defs = False
+disallow_subclassing_any = False
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+
+# Be more lenient with examples
+warn_no_return = False
+warn_redundant_casts = False
+warn_unreachable = False
+warn_unused_ignores = False
+
+[mypy-asyncio]
+ignore_missing_imports = True
+
+[mypy-os]
+ignore_missing_imports = True
+
+[mypy-cribl_control_plane.*]
+ignore_missing_imports = False


### PR DESCRIPTION
Ref: Failure build:
https://github.com/criblio/cribl_control_plane_sdk_python/actions/runs/17553158864/job/49850360505?pr=91
```
     id="my-syslog-source",
     type=InputSyslogType2.SYSLOG,
     tcp_port=SYSLOG_PORT,
-    tls=InputSyslogTLSSettingsServerSide2(disabled=True)
+    tls2=InputSyslogTLSSettingsServerSide2(disabled=True)
 )
 
```