### PR TITLE
ci: harden GitHub Actions workflow security setup

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - '.github/workflows/**'
+      - '.github/actions/**'
   pull_request:
     paths:
       - '.github/workflows/**'
+      - '.github/actions/**'
 
 jobs:
   actionlint:
@@ -17,11 +19,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
         
       - name: Run actionlint
         uses: rhysd/actionlint@03d0035246f3e81f36aed592ffb4bebf33a03106
         with:
           fail-on-error: true
+
+      - name: Run zizmor
+        run: |
+          pip install zizmor==1.25.2
+          zizmor .
           
       - name: Summary
         if: failure()
@@ -29,6 +38,6 @@ jobs:
           {
             echo "## GitHub Actions Linting Failed"
             echo ""
-            echo "One or more workflow files have syntax issues."
+            echo "One or more workflow files have syntax or security issues."
             echo "Please check the logs above for details."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/examples_build.yml
+++ b/.github/workflows/examples_build.yml
@@ -3,6 +3,9 @@ name: Build Examples on PR
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   examples_build:
     runs-on: ubuntu-latest
@@ -29,7 +32,10 @@ jobs:
         
         echo "target_branch=$BASE_REF" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        persist-credentials: false
       
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
       with:

--- a/.github/workflows/sdk_generation_dev.yaml
+++ b/.github/workflows/sdk_generation_dev.yaml
@@ -1,9 +1,4 @@
 name: Generate Dev SDK
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
 
 on:
   workflow_dispatch:
@@ -16,6 +11,8 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Ensure workflow is run from dev branch
         run: |
@@ -29,6 +26,8 @@ jobs:
   version-check:
     needs: check-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       up_to_date: ${{ steps.compare.outputs.up_to_date }}
       local_version: ${{ steps.compare.outputs.local_version }}
@@ -38,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: dev
+          persist-credentials: false
 
       - name: Compare OpenAPI versions
         id: compare
@@ -48,6 +48,8 @@ jobs:
   compute-version:
     needs: check-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
@@ -56,6 +58,7 @@ jobs:
         with:
           ref: dev
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install required tools
         run: |
@@ -183,6 +186,11 @@ jobs:
   generate:
     needs: [version-check, compute-version]
     if: needs.version-check.outputs.up_to_date != 'true'
+    permissions:
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@b823adc6be7d30b25198529f99f46303bc083534
     with:
       force: ${{ github.event.inputs.force }}
@@ -197,24 +205,29 @@ jobs:
     needs: [check-branch, version-check, generate]
     if: needs.generate.result == 'skipped'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Summary
+        env:
+          LOCAL_VERSION: ${{ needs.version-check.outputs.local_version }}
+          REMOTE_VERSION: ${{ needs.version-check.outputs.remote_version }}
         run: |
           {
             echo "## ⏭️ SDK Generation Skipped"
             echo ""
             echo "OpenAPI spec versions match - no generation needed:"
-            echo "- **Local** (out.openapi.yaml): \`${{ needs.version-check.outputs.local_version }}\`"
-            echo "- **Remote** (cribl-openapi-spec): \`${{ needs.version-check.outputs.remote_version }}\`"
+            echo "- **Local** (out.openapi.yaml): \`${LOCAL_VERSION}\`"
+            echo "- **Remote** (cribl-openapi-spec): \`${REMOTE_VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-slack-on-failure:
     needs: [check-branch, version-check, compute-version, generate]
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0
         with:
           payload: |
             {

--- a/.github/workflows/sdk_generation_prerelease.yaml
+++ b/.github/workflows/sdk_generation_prerelease.yaml
@@ -1,9 +1,4 @@
 name: Generate RC SDK (Prerelease)
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
 
 on:
   workflow_dispatch: {}
@@ -13,6 +8,8 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Ensure workflow is run from openapi-prerelease branch
         run: |
@@ -24,6 +21,8 @@ jobs:
   compute-version:
     needs: check-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
@@ -32,6 +31,7 @@ jobs:
         with:
           ref: openapi-prerelease
           fetch-depth: 0
+          persist-credentials: false
 
 
       - name: Compute prerelease version (X.Y.Zrc<n>)
@@ -139,6 +139,11 @@ jobs:
 
   generate:
     needs: [check-branch, compute-version]
+    permissions:
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@b823adc6be7d30b25198529f99f46303bc083534
     with:
       force: true
@@ -153,9 +158,10 @@ jobs:
     needs: [check-branch, compute-version, generate]
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0
         with:
           payload: |
             {

--- a/.github/workflows/sdk_generation_prod.yaml
+++ b/.github/workflows/sdk_generation_prod.yaml
@@ -1,10 +1,4 @@
 name: Generate Prod SDK
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
-  actions: write
 "on":
   workflow_dispatch:
     inputs:
@@ -24,6 +18,8 @@ permissions:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Ensure workflow is run from main branch
         run: |
@@ -35,6 +31,8 @@ jobs:
   version-check:
     needs: check-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       up_to_date: ${{ steps.compare.outputs.up_to_date }}
       local_version: ${{ steps.compare.outputs.local_version }}
@@ -44,6 +42,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: main
+          persist-credentials: false
 
       - name: Compare OpenAPI versions
         id: compare
@@ -54,6 +53,11 @@ jobs:
   generate:
     needs: [check-branch, version-check]
     if: needs.version-check.outputs.up_to_date != 'true'
+    permissions:
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@b823adc6be7d30b25198529f99f46303bc083534
     with:
       force: ${{ github.event.inputs.force }}
@@ -68,21 +72,27 @@ jobs:
     needs: [check-branch, version-check, generate]
     if: github.event_name == 'schedule' && needs.generate.result == 'skipped'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Summary
+        env:
+          LOCAL_VERSION: ${{ needs.version-check.outputs.local_version }}
+          REMOTE_VERSION: ${{ needs.version-check.outputs.remote_version }}
         run: |
           {
             echo "## ⏭️ SDK Generation Skipped (Cron)"
             echo ""
             echo "OpenAPI spec versions match - no generation needed:"
-            echo "- **Local** (out.openapi.yaml): \`${{ needs.version-check.outputs.local_version }}\`"
-            echo "- **Remote** (cribl-openapi-spec): \`${{ needs.version-check.outputs.remote_version }}\`"
+            echo "- **Local** (out.openapi.yaml): \`${LOCAL_VERSION}\`"
+            echo "- **Remote** (cribl-openapi-spec): \`${REMOTE_VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   dispatch-dev-stage:
     needs: generate
     if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -118,9 +128,10 @@ jobs:
     needs: [check-branch, version-check, generate, dispatch-dev-stage]
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0
         with:
           payload: |
             {

--- a/.github/workflows/sdk_generation_stage.yaml
+++ b/.github/workflows/sdk_generation_stage.yaml
@@ -1,9 +1,4 @@
 name: Generate Stage SDK
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
 
 on:
   workflow_dispatch:
@@ -16,6 +11,8 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Ensure workflow is run from stage branch
         run: |
@@ -29,6 +26,8 @@ jobs:
   version-check:
     needs: check-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       up_to_date: ${{ steps.compare.outputs.up_to_date }}
       local_version: ${{ steps.compare.outputs.local_version }}
@@ -38,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: stage
+          persist-credentials: false
 
       - name: Compare OpenAPI versions
         id: compare
@@ -48,6 +48,8 @@ jobs:
   compute-version:
     needs: check-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
@@ -56,6 +58,7 @@ jobs:
         with:
           ref: stage
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install required tools
         run: |
@@ -183,6 +186,11 @@ jobs:
   generate:
     needs: [version-check, compute-version]
     if: needs.version-check.outputs.up_to_date != 'true'
+    permissions:
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@b823adc6be7d30b25198529f99f46303bc083534
     with:
       force: ${{ github.event.inputs.force }}
@@ -197,24 +205,29 @@ jobs:
     needs: [check-branch, version-check, generate]
     if: needs.generate.result == 'skipped'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Summary
+        env:
+          LOCAL_VERSION: ${{ needs.version-check.outputs.local_version }}
+          REMOTE_VERSION: ${{ needs.version-check.outputs.remote_version }}
         run: |
           {
             echo "## ⏭️ SDK Generation Skipped"
             echo ""
             echo "OpenAPI spec versions match - no generation needed:"
-            echo "- **Local** (out.openapi.yaml): \`${{ needs.version-check.outputs.local_version }}\`"
-            echo "- **Remote** (cribl-openapi-spec): \`${{ needs.version-check.outputs.remote_version }}\`"
+            echo "- **Local** (out.openapi.yaml): \`${LOCAL_VERSION}\`"
+            echo "- **Remote** (cribl-openapi-spec): \`${REMOTE_VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-slack-on-failure:
     needs: [check-branch, version-check, compute-version, generate]
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0
         with:
           payload: |
             {

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -1,9 +1,4 @@
 name: Publish SDK
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
 
 on:
   push:
@@ -19,6 +14,8 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       branch: ${{ steps.branch-info.outputs.branch }}
       is-production: ${{ steps.branch-info.outputs.is-production }}
@@ -26,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Get branch information
         id: branch-info
@@ -64,6 +63,11 @@ jobs:
 
   publish:
     needs: check-branch
+    permissions:
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@b823adc6be7d30b25198529f99f46303bc083534
     with:
       target: cribl-control-plane
@@ -75,9 +79,11 @@ jobs:
   restore-workflow-lock:
     needs: [check-branch, publish]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,32 +101,15 @@ jobs:
 
       - name: Restore workflow.lock from GA tag
         if: needs.check-branch.outputs.branch == 'main' && needs.check-branch.outputs.is-prerelease == 'true'
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          CURRENT_BRANCH: ${{ needs.check-branch.outputs.branch }}
         run: |
           set -euo pipefail
           
-          # Fetch latest GA release from GitHub (with retry)
-          MAX_ATTEMPTS=5
-          attempt=1
-          LAST_GA_TAG=""
-          
-          while [ $attempt -le $MAX_ATTEMPTS ]; do
-            echo "Fetching latest GA release from GitHub (attempt $attempt/$MAX_ATTEMPTS)..."
-            LAST_GA_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
-            
-            if [[ "$LAST_GA_TAG" != "null" && -n "$LAST_GA_TAG" ]]; then
-              break
-            fi
-            
-            if [ $attempt -lt $MAX_ATTEMPTS ]; then
-              echo "⚠️  No release found (attempt $attempt/$MAX_ATTEMPTS), retrying in 2s..."
-              sleep 2
-              attempt=$((attempt + 1))
-            else
-              echo "❌ Error: No releases found on GitHub after $MAX_ATTEMPTS attempts"
-              exit 1
-            fi
-          done
-          
+          # Example: curl -s https://api.github.com/repos/criblio/cribl-control-plane-sdk-python/releases/latest | jq -r '.tag_name'
+          echo "Fetching latest GA release from GitHub..."
+          LAST_GA_TAG=$(curl -s "https://api.github.com/repos/${GH_REPOSITORY}/releases/latest" | jq -r '.tag_name')
           echo "✅ Latest GA tag: ${LAST_GA_TAG}"
           
           echo "Fetching tags from repository..."
@@ -148,18 +137,18 @@ jobs:
           echo "Committing workflow.lock restoration..."
           git commit -m "Revert workflow.lock to ${LAST_GA_TAG} for GA release" || echo "No changes to commit, workflow.lock already in sync"
           
-          CURRENT_BRANCH="${{ needs.check-branch.outputs.branch }}"
           echo "Pushing changes to ${CURRENT_BRANCH} branch..."
-          git push origin ${CURRENT_BRANCH}
+          git push origin "${CURRENT_BRANCH}"
           echo "✅ Successfully restored workflow.lock from ${LAST_GA_TAG}"
 
   notify-slack-on-failure:
     needs: [check-branch, publish, restore-workflow-lock]
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0
         with:
           payload: |
             {

--- a/.github/workflows/sdk_test.yaml
+++ b/.github/workflows/sdk_test.yaml
@@ -1,9 +1,4 @@
 name: Test
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
 "on":
   pull_request:
     branches:
@@ -17,6 +12,11 @@ permissions:
         type: string
 jobs:
   test:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-test.yaml@b823adc6be7d30b25198529f99f46303bc083534
     with:
       target: ${{ github.event.inputs.target || 'cribl-control-plane' }}

--- a/.github/workflows/sync_dev.yaml
+++ b/.github/workflows/sync_dev.yaml
@@ -8,9 +8,11 @@ on:
 jobs:
   merge-main-to-dev:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout full repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 
@@ -29,9 +31,11 @@ jobs:
 
   sync-speakeasy-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout full repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-speakeasy-version.yml
+++ b/.github/workflows/update-speakeasy-version.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 
@@ -43,99 +43,115 @@ jobs:
 
       - name: Check if update is needed
         id: check-update
+        env:
+          CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
+          LATEST_VERSION: ${{ steps.speakeasy-version.outputs.version }}
         run: |
-          if [ "${{ steps.current-version.outputs.version }}" = "${{ steps.speakeasy-version.outputs.version }}" ]; then
-            echo "Speakeasy version is already up to date (${{ steps.current-version.outputs.version }})"
+          if [ "${CURRENT_VERSION}" = "${LATEST_VERSION}" ]; then
+            echo "Speakeasy version is already up to date (${CURRENT_VERSION})"
             echo "needs_update=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Update needed: ${{ steps.current-version.outputs.version }} -> ${{ steps.speakeasy-version.outputs.version }}"
+            echo "Update needed: ${CURRENT_VERSION} -> ${LATEST_VERSION}"
             echo "needs_update=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update workflow.yaml
         if: steps.check-update.outputs.needs_update == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
+          LATEST_VERSION: ${{ steps.speakeasy-version.outputs.version }}
         run: |
           # Update the speakeasyVersion in workflow.yaml
-          sed -i "s/speakeasyVersion: .*/speakeasyVersion: ${{ steps.speakeasy-version.outputs.version }}/" .speakeasy/workflow.yaml
+          sed -i "s/speakeasyVersion: .*/speakeasyVersion: ${LATEST_VERSION}/" .speakeasy/workflow.yaml
           
           echo "Updated .speakeasy/workflow.yaml:"
-          echo "Before: speakeasyVersion: ${{ steps.current-version.outputs.version }}"
-          echo "After:  speakeasyVersion: ${{ steps.speakeasy-version.outputs.version }}"
+          echo "Before: speakeasyVersion: ${CURRENT_VERSION}"
+          echo "After:  speakeasyVersion: ${LATEST_VERSION}"
 
       - name: Verify changes
         if: steps.check-update.outputs.needs_update == 'true'
+        env:
+          LATEST_VERSION: ${{ steps.speakeasy-version.outputs.version }}
         run: |
           echo "Changes made to .speakeasy/workflow.yaml:"
           git diff --no-index /dev/null .speakeasy/workflow.yaml || true
           
           # Check that the change was applied correctly
           updated_version=$(grep "speakeasyVersion:" .speakeasy/workflow.yaml | sed 's/speakeasyVersion: //')
-          if [ "$updated_version" = "${{ steps.speakeasy-version.outputs.version }}" ]; then
+          if [ "$updated_version" = "${LATEST_VERSION}" ]; then
             echo "Version successfully updated to $updated_version"
           else
-            echo "Version update failed. Expected: ${{ steps.speakeasy-version.outputs.version }}, Got: $updated_version"
+            echo "Version update failed. Expected: ${LATEST_VERSION}, Got: $updated_version"
             exit 1
           fi
 
       - name: Create pull request with changes
         if: steps.check-update.outputs.needs_update == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_VERSION: ${{ steps.speakeasy-version.outputs.version }}
+          CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
+          # shellcheck disable=SC2153
+          COMMIT_MESSAGE: ${{ github.event.inputs.commit_message }}
         run: |
           # Configure git
           git config user.name "SyncUpBot"
           git config user.email "syncupbot@users.noreply.github.com"
           
           # Create a new branch for the update
-          branch_name="update-speakeasy-version-${{ steps.speakeasy-version.outputs.version }}"
+          branch_name="update-speakeasy-version-${LATEST_VERSION}"
           git checkout -b "$branch_name"
           
           # Add changes
           git add .speakeasy/workflow.yaml
           
           # Use custom commit message if provided, otherwise use default
-          commit_message="${{ github.event.inputs.commit_message }}"
-          if [ -z "$commit_message" ]; then
-            commit_message="chore: update Speakeasy version from ${{ steps.current-version.outputs.version }} to ${{ steps.speakeasy-version.outputs.version }}"
+          if [ -z "${COMMIT_MESSAGE}" ]; then
+            COMMIT_MESSAGE="chore: update Speakeasy version from ${CURRENT_VERSION} to ${LATEST_VERSION}"
           fi
           
           # Commit changes
-          git commit -m "$commit_message"
+          git commit -m "${COMMIT_MESSAGE}"
           
           # Push the new branch
           git push origin "$branch_name"
           
           # Create pull request using GitHub CLI
           gh pr create \
-            --title "Update Speakeasy version to ${{ steps.speakeasy-version.outputs.version }}" \
-            --body "Updates Speakeasy version from ${{ steps.current-version.outputs.version }} to ${{ steps.speakeasy-version.outputs.version }}." \
+            --title "Update Speakeasy version to ${LATEST_VERSION}" \
+            --body "Updates Speakeasy version from ${CURRENT_VERSION} to ${LATEST_VERSION}." \
             --head "$branch_name" \
             --base main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create summary
+        env:
+          NEEDS_UPDATE: ${{ steps.check-update.outputs.needs_update }}
+          CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
+          LATEST_VERSION: ${{ steps.speakeasy-version.outputs.version }}
+          TAG_NAME: ${{ steps.speakeasy-version.outputs.tag_name }}
         run: |
-          if [ "${{ steps.check-update.outputs.needs_update }}" = "true" ]; then
+          if [ "${NEEDS_UPDATE}" = "true" ]; then
             {
               echo "## Speakeasy Version Update Summary"
               echo ""
               echo "### Pull Request Created"
-              echo "- **Previous Version:** ${{ steps.current-version.outputs.version }}"
-              echo "- **New Version:** ${{ steps.speakeasy-version.outputs.version }}"
-              echo "- **Release Tag:** ${{ steps.speakeasy-version.outputs.tag_name }}"
+              echo "- **Previous Version:** ${CURRENT_VERSION}"
+              echo "- **New Version:** ${LATEST_VERSION}"
+              echo "- **Release Tag:** ${TAG_NAME}"
               echo "- **File Updated:** \`.speakeasy/workflow.yaml\`"
-              echo "- **Branch:** \`update-speakeasy-version-${{ steps.speakeasy-version.outputs.version }}\`"
+              echo "- **Branch:** \`update-speakeasy-version-${LATEST_VERSION}\`"
               echo ""
               echo "A pull request has been created with the version update. Please review and merge it to apply the changes."
               echo ""
-              echo "[View latest Speakeasy release](https://github.com/speakeasy-api/speakeasy/releases/tag/${{ steps.speakeasy-version.outputs.tag_name }})"
+              echo "[View latest Speakeasy release](https://github.com/speakeasy-api/speakeasy/releases/tag/${TAG_NAME})"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             {
               echo "## Speakeasy Version Update Summary"
               echo ""
               echo "### No Update Needed"
-              echo "- **Current Version:** ${{ steps.current-version.outputs.version }}"
-              echo "- **Latest Available:** ${{ steps.speakeasy-version.outputs.version }}"
+              echo "- **Current Version:** ${CURRENT_VERSION}"
+              echo "- **Latest Available:** ${LATEST_VERSION}"
               echo ""
               echo "Your Speakeasy version is already up to date!"
             } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Apply least-privilege job permissions, disable persisted checkout credentials where possible, add zizmor scanning, and pin Slack notification action SHAs to reduce workflow supply-chain risk.