### PR TITLE
DOC-5243: Remove comment for Syslog Source id in config

### DIFF
--- a/examples/example_cloud_configure_resources.py
+++ b/examples/example_cloud_configure_resources.py
@@ -99,7 +99,7 @@ group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 # user-supplied parameters block. This configuration is passed to the API 
 # in the Create Source block.
 syslog_source = CreateInputInputSyslogSyslog2(
-    id="in-syslog-9021",  # Port number in name should match the SYSLOG_PORT value
+    id="in-syslog-9021",
     type=CreateInputInputSyslogType2.SYSLOG,
     host="0.0.0.0",
     tcp_port=SYSLOG_PORT,

--- a/examples/example_onprem_configure_resources.py
+++ b/examples/example_onprem_configure_resources.py
@@ -92,7 +92,7 @@ group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 # user-supplied parameters block. This configuration is passed to the API 
 # in the Create Source block.
 syslog_source = CreateInputInputSyslogSyslog2(
-    id="in-syslog-9021",  # Port number in name should match the SYSLOG_PORT value
+    id="in-syslog-9021",
     type=CreateInputInputSyslogType2.SYSLOG,
     host="0.0.0.0",
     tcp_port=SYSLOG_PORT,


### PR DESCRIPTION
Removes the comment ` # Port number in name should match the SYSLOG_PORT value` for line `id="in-syslog-9021",` in the Source definition block in both `configure_resources` examples.