### PR TITLE
DOC-5344: Expand comments in the Configure Worker Groups code examples

### DIFF
--- a/examples/example_cloud_commit_deploy.py
+++ b/examples/example_cloud_commit_deploy.py
@@ -1,31 +1,71 @@
 """
-Replace the placeholder values for ORG_ID, CLIENT_ID, CLIENT_SECRET,
-and WORKSPACE_NAME with your Organization ID, Client ID and Secret, and
-Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, follow the steps
-at https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
+Commit and deploy configuration
 
-Your Client ID and Secret are sensitive information and should be kept private.
+- Commits pending configuration changes for a Cribl Stream Worker Group in a 
+  Workspace, then deploys the commit so that Workers load it.
 
 NOTE: This example is for Cribl.Cloud deployments only.
+
+Required to use this example:
+- A Cribl.Cloud Organization ID and Workspace name, which are used to build the
+base URL for the SDK calls.
+- The Client ID and Secret for a Cribl.Cloud API Credential, which are used to
+authenticate the SDK calls. To get the Client ID and Secret, follow
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud. The Client ID
+and Secret are sensitive information and should be kept private.
+- A Worker Group with pending changes to commit and deploy.
 """
 
+# Import block
+# Imports asyncio so that the file can run an asynchronous control plane
+# sequence for authentication, commit, and deploy.
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports model classes that provide the Python types used for Cribl Stream
+# resource configurations and API payloads in this file from the
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
 
-from cribl_control_plane.models import ProductsCore, Security, SchemeClientOauth
+from cribl_control_plane.models import (
+    ProductsCore,
+    SchemeClientOauth,
+    Security,
+)
 
-ORG_ID = "your-org-id"
-CLIENT_ID = "your-client-id"
-CLIENT_SECRET = "your-client-secret"
-WORKSPACE_NAME = "your-workspace-name"
-WORKER_GROUP_ID = "your-cloud-worker-group-id"  # Use the same Worker Group ID as in previous examples
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, Commit block, and Deploy
+# block. Replace the placeholder values before executing this file.
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+WORKSPACE_NAME = "your-workspace-name"  # Replace with the Workspace name
+WORKER_GROUP_ID = "your-cloud-worker-group-id"  # Replace with the Worker Group ID to commit and deploy
 
+CLIENT_ID = "your-client-id"  # Replace with the Client ID for the API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the Client Secret for the API Credential
+
+# URL block
+# Builds the base URL and Worker Group-specific URL to use for the API requests
+# that this file makes using the ORG_ID, WORKSPACE_NAME, and WORKER_GROUP_ID from
+# the user-supplied parameters block. The Worker Group URL is used for the Commit
+# block.
 base_url = f"https://{WORKSPACE_NAME}-{ORG_ID}.cribl.cloud/api/v1"
 group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your Cribl.Cloud API Credentials,
+# commits pending configuration for the Worker Group, and deploys that version.
 async def main():
-    # Create authenticated SDK client
+    # Authentication block
+    # Creates an OAuth client (SchemeClientOauth) that exchanges CLIENT_ID and
+    # CLIENT_SECRET from the user-supplied parameters block for a Bearer token
+    # and wraps the client in Security.
+    # Constructs the SDK client CriblControlPlane to make authenticated API
+    # requests using the base_url from the URL block and Security, which holds
+    # the Bearer token.
     client_oauth = SchemeClientOauth(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -36,31 +76,42 @@ async def main():
     security = Security(client_oauth=client_oauth)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Commit configuration changes
+    # Commit block
+    # Records a new version of the Worker Group configuration, marks that
+    # version as effective, and captures the commit ID to use in the Deploy
+    # block. Raises an exception if the API returns no commit. Otherwise, prints
+    # a confirmation message.
     commit_response = cribl.versions.commits.create(
         message="Commit for Cribl Stream example",
         effective=True,
         files=["."],
-        server_url=group_url
+        server_url=group_url,
     )
-    
+
     if not commit_response.items or len(commit_response.items) == 0:
         raise Exception("Failed to commit configuration changes")
-    
+
     version = commit_response.items[0].commit
     print(f"✅ Committed configuration changes to the group: {WORKER_GROUP_ID}, commit ID: {version}")
 
-    # Deploy configuration changes
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from the
+    # Commit block) to the Cribl Stream Worker Group so that Workers load and run
+    # that version, then prints a confirmation message.
     cribl.groups.deploy(
         product=ProductsCore.STREAM,
         id=WORKER_GROUP_ID,
-        version=version
+        version=version,
     )
     print(f"✅ Worker Group changes deployed: {WORKER_GROUP_ID}")
 
+
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
         print(f"❌ Something went wrong: {error}")
-

--- a/examples/example_cloud_create_worker_group.py
+++ b/examples/example_cloud_create_worker_group.py
@@ -2,6 +2,7 @@
 Create a Worker Group
 
 - Creates a new Worker Group in Cribl Stream.
+- Commits and deploys the Worker Group configuration to make it active.
 
 NOTE: This example is for Cribl.Cloud deployments only.
 
@@ -17,7 +18,7 @@ and Secret are sensitive information and should be kept private.
 
 # Import block
 # Imports asyncio so that the file can run an asynchronous control plane 
-# sequence for authentication and creating a Worker Group.
+# sequence for authentication and creating and deploying a Worker Group.
 #
 # Imports CriblControlPlane as the API client from the cribl_control_plane 
 # SDK package.
@@ -51,9 +52,11 @@ CLIENT_ID = "your-client-id"  # Replace with the Client ID for the API Credentia
 CLIENT_SECRET = "your-client-secret"  # Replace with the Client Secret for the API Credential
 
 # URL block
-# Builds the base URL to use for the API requests that this file makes using 
-# the ORG_ID and WORKSPACE_NAME provided in the user-supplied parameters block.
+# Builds the base URL and Worker Group-specific URL to use for the 
+# API requests that this file makes using the ORG_ID, WORKSPACE_NAME, 
+# and WORKER_GROUP_ID provided in the user-supplied parameters block.
 base_url = f"https://{WORKSPACE_NAME}-{ORG_ID}.cribl.cloud/api/v1"
+group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 
 # Estimated ingest rate block
 # Sets the maximum estimated ingest throughput tier for the new Worker Group
@@ -67,7 +70,7 @@ ESTIMATED_INGEST_RATE = EstimatedIngestRateOptionsConfigGroup.RATE24_MB_PER_SEC
 # The configuration for a new Worker Group that uses the WORKER_GROUP_ID 
 # provided in the user-supplied parameters block. The settings in this
 # configuration are passed to groups.create in the Create Worker Group block, 
-# with ESTIMATED_INGEST_RATE from the Estimated ingest rate block.
+# with ESTIMATED_INGEST_RATE from the estimated ingest rate block.
 group = ConfigGroup(
     id=WORKER_GROUP_ID,
     name="my-worker-group",
@@ -82,8 +85,8 @@ group = ConfigGroup(
 
 # Workflow block
 # The async function that contains the full automation and runs when you 
-# execute this file. Authenticates using your Cribl.Cloud API Credentials and 
-# creates the Worker Group.
+# execute this file. Authenticates using your Cribl.Cloud API Credentials, 
+# creates the Worker Group, and commits and deploys the configuration.
 async def main():
     # Authentication block
     # Creates an OAuth client (SchemeClientOauth) that exchanges CLIENT_ID and 
@@ -127,6 +130,38 @@ async def main():
         provisioned=group.provisioned,
     )
     print(f"✅ Worker Group created: {group.id}")
+
+    # Commit block
+    # Records a new version of the Worker Group configuration, marks that 
+    # version as effective, and captures the commit ID to use in the 
+    # Deploy block. Raises an exception if the API returns no commit. 
+    # Otherwise, prints a confirmation message.
+    commit_response = cribl.versions.commits.create(
+        message="Commit for create Worker Group example",
+        effective=True,
+        files=["."],
+        server_url=group_url,
+    )
+
+    if not commit_response.items or len(commit_response.items) == 0:
+        raise Exception("Failed to commit configuration changes")
+
+    version = commit_response.items[0].commit
+    print(
+        f"✅ Committed configuration changes to the group: {group.id}, "
+        f"commit ID: {version}"
+    )
+
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from 
+    # the Commit block) to the Cribl Stream Worker Group so that Workers load 
+    # and run that version, then prints a confirmation message.
+    cribl.groups.deploy(
+        product=ProductsCore.STREAM,
+        id=group.id,
+        version=version,
+    )
+    print(f"✅ Worker Group changes deployed: {group.id}")
 
 # Script entry block
 # Starts the async function main() with the standard library helper 

--- a/examples/example_cloud_create_worker_group.py
+++ b/examples/example_cloud_create_worker_group.py
@@ -1,14 +1,30 @@
 """
-Replace the placeholder values for ORG_ID, CLIENT_ID, CLIENT_SECRET,
-and WORKSPACE_NAME with your Organization ID, Client ID and Secret, and
-Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, follow the steps
-at https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
+Create a Worker Group
 
-Your Client ID and Secret are sensitive information and should be kept private.
+- Creates a new Worker Group in Cribl Stream.
 
 NOTE: This example is for Cribl.Cloud deployments only.
+
+Required to use this example:
+- A Cribl.Cloud Enterprise account.
+- A Cribl.Cloud Organization ID and Workspace name, which are used to build the 
+base URL for the SDK calls.
+- The Client ID and Secret for a Cribl.Cloud API Credential, which are used to 
+authenticate the SDK calls. To get the Client ID and Secret, follow 
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud. The Client ID 
+and Secret are sensitive information and should be kept private.
 """
 
+# Import block
+# Imports asyncio so that the file can run an asynchronous control plane 
+# sequence for authentication and creating a Worker Group.
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane 
+# SDK package.
+#
+# Imports model classes that provide the Python types used for Cribl Stream 
+# resource configurations and API payloads in this file from the 
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
@@ -23,17 +39,35 @@ from cribl_control_plane.models import (
     EstimatedIngestRateOptionsConfigGroup,
 )
 
-ORG_ID = "your-org-id"
-CLIENT_ID = "your-client-id"
-CLIENT_SECRET = "your-client-secret"
-WORKSPACE_NAME = "your-workspace-name"
-WORKER_GROUP_ID = "your-cloud-worker-group-id"
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and Worker Group 
+# definition block. Replace the placeholder values before executing 
+# this file.
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+WORKSPACE_NAME = "your-workspace-name"  # Replace with the Workspace name
+WORKER_GROUP_ID = "your-group"  # Replace with the ID to use for the new Worker Group
 
+CLIENT_ID = "your-client-id"  # Replace with the Client ID for the API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the Client Secret for the API Credential
+
+# URL block
+# Builds the base URL to use for the API requests that this file makes using 
+# the ORG_ID and WORKSPACE_NAME provided in the user-supplied parameters block.
 base_url = f"https://{WORKSPACE_NAME}-{ORG_ID}.cribl.cloud/api/v1"
 
-# Equivalent to 24 MB/s maximum estimated ingest rate with 9 Worker Processes
+# Estimated ingest rate block
+# Sets the maximum estimated ingest throughput tier for the new Worker Group
+# using EstimatedIngestRateOptionsConfigGroup. RATE24_MB_PER_SEC is the 24 MB/s
+# tier, equivalent to 24 MB/s maximum estimated ingest rate with 9 Worker 
+# Processes. This value is passed as estimated_ingest_rate to groups.create in
+# the Create Worker Group block.
 ESTIMATED_INGEST_RATE = EstimatedIngestRateOptionsConfigGroup.RATE24_MB_PER_SEC
 
+# Worker Group definition block
+# The configuration for a new Worker Group that uses the WORKER_GROUP_ID 
+# provided in the user-supplied parameters block. The settings in this
+# configuration are passed to groups.create in the Create Worker Group block, 
+# with ESTIMATED_INGEST_RATE from the Estimated ingest rate block.
 group = ConfigGroup(
     id=WORKER_GROUP_ID,
     name="my-worker-group",
@@ -46,8 +80,18 @@ group = ConfigGroup(
     provisioned=False,
 )
 
+# Workflow block
+# The async function that contains the full automation and runs when you 
+# execute this file. Authenticates using your Cribl.Cloud API Credentials and 
+# creates the Worker Group.
 async def main():
-    # Create authenticated SDK client
+    # Authentication block
+    # Creates an OAuth client (SchemeClientOauth) that exchanges CLIENT_ID and 
+    # CLIENT_SECRET from the user-supplied parameters block for a Bearer 
+    # token and wraps the client in Security.
+    # Constructs the SDK client CriblControlPlane to make authenticated API 
+    # requests using the base_url from the URL block and Security, which holds 
+    # the Bearer token.
     client_oauth = SchemeClientOauth(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -58,13 +102,17 @@ async def main():
     security = Security(client_oauth=client_oauth)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Verify that Worker Group doesn't already exist
+    # Create Worker Group block
+    # Checks for a Worker Group with the WORKER_GROUP_ID provided in the 
+    # user-supplied parameters block and exits if it already exists. 
+    # Otherwise, creates the Worker Group using settings from the Worker Group 
+    # definition block and ESTIMATED_INGEST_RATE from the Estimated ingest 
+    # rate block and prints a confirmation message.
     worker_group_response = cribl.groups.get(id=group.id, product=ProductsCore.STREAM)
     if worker_group_response.items and len(worker_group_response.items) > 0:
         print(f"❌ Worker Group already exists: {group.id}. Try a different group ID.")
         return
 
-    # Create the worker group
     cribl.groups.create(
         product=ProductsCore.STREAM,
         id=group.id,
@@ -80,6 +128,10 @@ async def main():
     )
     print(f"✅ Worker Group created: {group.id}")
 
+# Script entry block
+# Starts the async function main() with the standard library helper 
+# asyncio.run and prints an error message if the run fails. Runs only when you 
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())

--- a/examples/example_cloud_list_worker_groups.py
+++ b/examples/example_cloud_list_worker_groups.py
@@ -1,30 +1,65 @@
 """
-Replace the placeholder values for ORG_ID, CLIENT_ID, CLIENT_SECRET,
-and WORKSPACE_NAME with your Organization ID, Client ID and Secret, and
-Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, follow the steps
-at https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
+List Worker Groups
 
-Your Client ID and Secret are sensitive information and should be kept private.
+- Lists all Worker Group configurations for Cribl Stream in a Workspace.
 
 NOTE: This example is for Cribl.Cloud deployments only.
+
+Required to use this example:
+- A Cribl.Cloud Organization ID and Workspace name, which are used to build the
+base URL for the SDK calls.
+- The Client ID and Secret for a Cribl.Cloud API Credential, which are used to
+authenticate the SDK calls. To get the Client ID and Secret, follow
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud. The Client ID
+and Secret are sensitive information and should be kept private.
 """
 
+# Import block
+# Imports asyncio so that the file can run an asynchronous control plane
+# sequence for authentication and listing Worker Groups.
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports model classes that provide the Python types used for Cribl Stream
+# resource configurations and API payloads in this file from the
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
 
-from cribl_control_plane.models import (ProductsCore, SchemeClientOauth,
-                                        Security)
+from cribl_control_plane.models import (
+    ProductsCore,
+    SchemeClientOauth,
+    Security,
+)
 
-ORG_ID = "your-org-id"
-CLIENT_ID = "your-client-id"
-CLIENT_SECRET = "your-client-secret"
-WORKSPACE_NAME = "your-workspace-name"
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and List Worker Groups
+# block. Replace the placeholder values before executing this file.
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+WORKSPACE_NAME = "your-workspace-name"  # Replace with the Workspace name
 
+CLIENT_ID = "your-client-id"  # Replace with the Client ID for the API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the Client Secret for the API Credential
+
+# URL block
+# Builds the base URL to use for the API requests that this file makes using the
+# ORG_ID and WORKSPACE_NAME provided in the user-supplied parameters block.
 base_url = f"https://{WORKSPACE_NAME}-{ORG_ID}.cribl.cloud/api/v1"
 
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your Cribl.Cloud API Credentials and
+# lists Worker Groups for Cribl Stream.
 async def main():
-    # Create authenticated SDK client
+    # Authentication block
+    # Creates an OAuth client (SchemeClientOauth) that exchanges CLIENT_ID and
+    # CLIENT_SECRET from the user-supplied parameters block for a Bearer token
+    # and wraps the client in Security.
+    # Constructs the SDK client CriblControlPlane to make authenticated API
+    # requests using the base_url from the URL block and Security, which holds
+    # the Bearer token.
     client_oauth = SchemeClientOauth(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -35,7 +70,10 @@ async def main():
     security = Security(client_oauth=client_oauth)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Retrieve and list all Worker Groups
+    # List Worker Groups block
+    # Calls groups.list for Cribl Stream (ProductsCore.STREAM). If the response
+    # includes items, prints each Worker Group configuration; otherwise prints
+    # that no Worker Groups were found.
     worker_groups_response = cribl.groups.list(product=ProductsCore.STREAM)
 
     if worker_groups_response.items:
@@ -45,9 +83,12 @@ async def main():
     else:
         print(f"❌ No Worker Groups found.")
 
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
         print(f"❌ Something went wrong: {error}")
-

--- a/examples/example_cloud_replicate_worker_group.py
+++ b/examples/example_cloud_replicate_worker_group.py
@@ -1,22 +1,41 @@
 """
-Replace the placeholder values for ORG_ID, CLIENT_ID, CLIENT_SECRET,
-and WORKSPACE_NAME with your Organization ID, Client ID and Secret, and
-Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, follow
-the steps at https://docs.cribl.io/cribl-as-code/authentication/#cloud-auth.
-Your Client ID and Secret are sensitive information and should be kept private.
+Replicate a Worker Group
+
+- Verifies that a source Worker Group exists in Cribl Stream.
+- Creates a replica Worker Group cloned from the source with the 
+same configuration.
+- Commits and deploys the replica Worker Group configuration to make it active.
 
 NOTE: This example is for Cribl.Cloud deployments only.
+
+Required to use this example:
+- A Cribl.Cloud Enterprise account.
+- A Cribl.Cloud Organization ID and Workspace name, which are used to build the
+base URL for the SDK calls.
+- The Client ID and Secret for a Cribl.Cloud API Credential, which are used to
+authenticate the SDK calls. To get the Client ID and Secret, follow
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud. The Client ID
+and Secret are sensitive information and should be kept private.
+- An existing Worker Group to replicate.
 """
 
+# Import block
+# Imports asyncio so that the file can run an asynchronous control plane
+# sequence for authentication, replicating a Worker Group, and committing and
+# deploying the replica configuration.
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports model classes that provide the Python types used for Cribl Stream
+# resource configurations and API payloads in this file from the
+# cribl_control_plane.models subpackage.
 import asyncio
-
-from typing import Optional
 
 from cribl_control_plane import CriblControlPlane
 
 from cribl_control_plane.models import (
     CloudProvider,
-    ConfigGroup,
     ConfigGroupCloud,
     EstimatedIngestRateOptionsConfigGroup,
     ProductsCore,
@@ -24,17 +43,45 @@ from cribl_control_plane.models import (
     Security,
 )
 
-ORG_ID = "your-org-id"
-CLIENT_ID = "your-client-id"
-CLIENT_SECRET = "your-client-secret"
-WORKSPACE_NAME = "your-workspace-name"
-SOURCE_WORKER_GROUP_ID = "my-worker-group" # The id of the Worker Group to clone
-REPLICA_WORKER_GROUP_ID = "my-replica-worker-group" # The id to use for the replica Worker Group
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and Replicate Worker
+# Group block. Replace the placeholder values before executing this file.
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+WORKSPACE_NAME = "your-workspace-name"  # Replace with the Workspace name
+SOURCE_WORKER_GROUP_ID = "my-worker-group"  # Replace with the ID of the Worker Group to clone
+REPLICA_WORKER_GROUP_ID = "my-replica-worker-group"  # Replace with the ID for the new replica Worker Group
 
+CLIENT_ID = "your-client-id"  # Replace with the Client ID for the API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the Client Secret for the API Credential
+
+# URL block
+# Builds the base URL and replica Worker Group-specific URL to use for the API
+# requests that this file makes using the ORG_ID, WORKSPACE_NAME, and
+# REPLICA_WORKER_GROUP_ID from the user-supplied parameters block.
 base_url = f"https://{WORKSPACE_NAME}-{ORG_ID}.cribl.cloud/api/v1"
+group_url = f"{base_url}/m/{REPLICA_WORKER_GROUP_ID}"
 
-async def main() -> None:
-    """Main function that demonstrates Worker Group replication"""
+# Estimated ingest rate block
+# Sets the maximum estimated ingest throughput tier for the replica Worker Group
+# using EstimatedIngestRateOptionsConfigGroup. RATE24_MB_PER_SEC is the 24 MB/s
+# tier, equivalent to 24 MB/s maximum estimated ingest rate with 9 Worker
+# Processes. This value is passed as estimated_ingest_rate to groups.create in
+# the Replicate Worker Group block.
+ESTIMATED_INGEST_RATE = EstimatedIngestRateOptionsConfigGroup.RATE24_MB_PER_SEC
+
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your Cribl.Cloud API Credentials,
+# verifies the source Worker Group, creates the replica, and commits and deploys
+# the replica configuration.
+async def main():
+    # Authentication block
+    # Creates an OAuth client (SchemeClientOauth) that exchanges CLIENT_ID and
+    # CLIENT_SECRET from the user-supplied parameters block for a Bearer token
+    # and wraps the client in Security.
+    # Constructs the SDK client CriblControlPlane to make authenticated API
+    # requests using the base_url from the URL block and Security, which holds
+    # the Bearer token.
     client_oauth = SchemeClientOauth(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -45,52 +92,81 @@ async def main() -> None:
     security = Security(client_oauth=client_oauth)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    try:
-        # Verify that the source Worker Group exists
-        source_group_response = cribl.groups.get(id=SOURCE_WORKER_GROUP_ID, product=ProductsCore.STREAM)
-        if not source_group_response.items or len(source_group_response.items) == 0:
-            print(f"❌ Source Worker Group not found: {SOURCE_WORKER_GROUP_ID}. Create the source Worker Group first.")
-            exit(1)
-
-        # Replicate the Worker Group
-        replicate_worker_group(cribl, SOURCE_WORKER_GROUP_ID)
-
-    except Exception as error:
-        message = str(error)
-        print(f"Error: {message}")
-        exit(1)
-
-def replicate_worker_group(
-    cribl: CriblControlPlane, source_id: str
-) -> Optional[ConfigGroup]:
-    """
-    Replicates a Worker Group with a unique ID
-    """
-    # Verify that the replica Worker Group does not exist
-    replica_group_response = cribl.groups.get(id=REPLICA_WORKER_GROUP_ID, product=ProductsCore.STREAM)
-    if replica_group_response.items and len(replica_group_response.items) > 0:
-        print(f"❌ Replica Worker Group already exists: {REPLICA_WORKER_GROUP_ID}. Try a different group ID.")
+    # Verify source Worker Group block
+    # Fetches the source Worker Group using SOURCE_WORKER_GROUP_ID from the
+    # user-supplied parameters block. Exits with a message if the group does not
+    # exist so replication does not run without a valid clone source.
+    source_group_response = cribl.groups.get(
+        id=SOURCE_WORKER_GROUP_ID, product=ProductsCore.STREAM
+    )
+    if not source_group_response.items or len(source_group_response.items) == 0:
+        print(f"❌ Source Worker Group not found: {SOURCE_WORKER_GROUP_ID}. Create the source Worker Group first.")
         return
+
+    # Replicate Worker Group block
+    # Checks for a Worker Group with REPLICA_WORKER_GROUP_ID from the user-supplied
+    # parameters block and exits if it already exists. Otherwise, creates the
+    # replica using groups.create with source_group_id set to the source Worker
+    # Group ID, cloud settings, and ESTIMATED_INGEST_RATE from the Estimated
+    # ingest rate block, then prints a confirmation message.
+    replica_group_response = cribl.groups.get(
+        id=REPLICA_WORKER_GROUP_ID, product=ProductsCore.STREAM
+    )
+    if replica_group_response.items and len(replica_group_response.items) > 0:
+        print(f"❌ Replica Worker Group already exists: {REPLICA_WORKER_GROUP_ID}. Try a different Worker Group ID.")
+        return
+
     cribl.groups.create(
         product=ProductsCore.STREAM,
         id=REPLICA_WORKER_GROUP_ID,
         name="my-replica-worker-group",
-        description=f"Worker Group cloned from {source_id} with identical configuration",
+        description=f"Worker Group cloned from {SOURCE_WORKER_GROUP_ID} with identical configuration",
         cloud=ConfigGroupCloud(provider=CloudProvider.AWS, region="us-east-1"),
         worker_remote_access=True,
         is_fleet=False,
         is_search=False,
         on_prem=False,
-        estimated_ingest_rate=EstimatedIngestRateOptionsConfigGroup.RATE24_MB_PER_SEC,  # Equivalent to 24 MB/s maximum estimated ingest rate with 9 Worker Processes
-        source_group_id=source_id,
+        estimated_ingest_rate=ESTIMATED_INGEST_RATE,
+        source_group_id=SOURCE_WORKER_GROUP_ID,
     )
-    print(f"✅ Worker Group replicated: {REPLICA_WORKER_GROUP_ID} (cloned from {source_id})")
+    print(f"✅ Worker Group replicated: {REPLICA_WORKER_GROUP_ID} (cloned from {SOURCE_WORKER_GROUP_ID})")
+
+    # Commit block
+    # Records a new version of the replica Worker Group configuration, marks that
+    # version as effective, and captures the commit ID to use in the Deploy
+    # block. Raises an exception if the API returns no commit. Otherwise, prints
+    # a confirmation message. Uses group_url from the URL block.
+    commit_response = cribl.versions.commits.create(
+        message="Commit for replicate Worker Group example",
+        effective=True,
+        files=["."],
+        server_url=group_url,
+    )
+
+    if not commit_response.items or len(commit_response.items) == 0:
+        raise Exception("Failed to commit configuration changes")
+
+    version = commit_response.items[0].commit
+    print(f"✅ Committed configuration changes to the group: {REPLICA_WORKER_GROUP_ID}, commit ID: {version}")
+
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from the
+    # Commit block) to the Cribl Stream replica Worker Group so that Workers load
+    # and run that version, then prints a confirmation message.
+    cribl.groups.deploy(
+        product=ProductsCore.STREAM,
+        id=REPLICA_WORKER_GROUP_ID,
+        version=version,
+    )
+    print(f"✅ Worker Group changes deployed: {REPLICA_WORKER_GROUP_ID}")
 
 
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
-        message = str(error)
-        print(f"❌ Something went wrong: {message}")
-
+        print(f"❌ Something went wrong: {error}")

--- a/examples/example_cloud_scale_worker_group.py
+++ b/examples/example_cloud_scale_worker_group.py
@@ -1,53 +1,83 @@
 """
-Replace the placeholder values for ORG_ID, CLIENT_ID, CLIENT_SECRET,
-and WORKSPACE_NAME with your Organization ID, Client ID and Secret, and
-Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, follow the steps
-at https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
+Scale (Provision) a Worker Group
 
-Your Client ID and Secret are sensitive information and should be kept private.
+- Verifies that a Worker Group exists in Cribl Stream.
+- Updates estimated ingest rate and provisioning for the Worker Group.
+- Commits and deploys the Worker Group configuration to make it active.
 
 NOTE: This example is for Cribl.Cloud deployments only.
+
+Required to use this example:
+- A Cribl.Cloud Enterprise account (if you are scaling a non-default Worker Group).
+- A Cribl.Cloud Organization ID and Workspace name, which are used to build the
+base URL for the SDK calls.
+- The Client ID and Secret for a Cribl.Cloud API Credential, which are used to
+authenticate the SDK calls. To get the Client ID and Secret, follow
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud. The Client ID
+and Secret are sensitive information and should be kept private.
+- An existing Worker Group ID (WORKER_GROUP_ID) to scale.
 """
 
+# Import block
+# Imports asyncio so that the file can run an asynchronous control plane
+# sequence for authentication, scaling a Worker Group, and committing and
+# deploying the configuration.
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports model classes that provide the Python types used for Cribl Stream
+# resource configurations and API payloads in this file from the
+# cribl_control_plane.models subpackage.
 import asyncio
-
-from typing import Optional
 
 from cribl_control_plane import CriblControlPlane
 
 from cribl_control_plane.models import (
-    ConfigGroup,
     ProductsCore,
     SchemeClientOauth,
     Security,
     EstimatedIngestRateOptionsConfigGroup,
 )
 
-ORG_ID = "your-org-id"
-CLIENT_ID = "your-client-id"
-CLIENT_SECRET = "your-client-secret"
-WORKSPACE_NAME = "your-workspace-name"
-WORKER_GROUP_ID = "your-cloud-worker-group-id"  # Use the same Worker Group ID as in the previous example
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and Scale Worker Group
+# block. Replace the placeholder values before executing this file.
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+WORKSPACE_NAME = "your-workspace-name"  # Replace with the Workspace name
+WORKER_GROUP_ID = "your-cloud-worker-group-id"  # Replace with the Worker Group ID to scale
 
+CLIENT_ID = "your-client-id"  # Replace with the Client ID for the API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the Client Secret for the API Credential
+
+# URL block
+# Builds the base URL and Worker Group-specific URL to use for the API requests
+# that this file makes using the ORG_ID, WORKSPACE_NAME, and WORKER_GROUP_ID
+# from the user-supplied parameters block. The Worker Group URL is used for the
+# Commit block.
 base_url = f"https://{WORKSPACE_NAME}-{ORG_ID}.cribl.cloud/api/v1"
+group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 
-def resolve_group(cribl, group_id: str, product: ProductsCore) -> Optional[ConfigGroup]:
-    resp = cribl.groups.get(id=group_id, product=product)
+# Estimated ingest rate block
+# Target tier after scaling, using EstimatedIngestRateOptionsConfigGroup.
+# RATE48_MB_PER_SEC is the 48 MB/s tier, equivalent to 48 MB/s maximum estimated
+# ingest rate with 21 Worker Processes. This value is written to
+# estimated_ingest_rate in the Scale Worker Group block.
+SCALED_ESTIMATED_INGEST_RATE = EstimatedIngestRateOptionsConfigGroup.RATE48_MB_PER_SEC
 
-    # Case 1: List-style wrapper with items
-    items = getattr(resp, "items", None)
-    if items:
-        return items[0]
-
-    # Case 2: Direct ConfigGroup object
-    if isinstance(resp, ConfigGroup):
-        return resp
-
-    # Nothing found or unexpected shape
-    return None
-
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your Cribl.Cloud API Credentials,
+# verifies the Worker Group, updates scaling fields, and commits and deploys the
+# configuration.
 async def main():
-    # Create authenticated SDK client
+    # Authentication block
+    # Creates an OAuth client (SchemeClientOauth) that exchanges CLIENT_ID and
+    # CLIENT_SECRET from the user-supplied parameters block for a Bearer token
+    # and wraps the client in Security.
+    # Constructs the SDK client CriblControlPlane to make authenticated API
+    # requests using the base_url from the URL block and Security, which holds
+    # the Bearer token.
     client_oauth = SchemeClientOauth(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -58,35 +88,79 @@ async def main():
     security = Security(client_oauth=client_oauth)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Verify that Worker Group already exists
-    group = resolve_group(cribl, WORKER_GROUP_ID, ProductsCore.STREAM)
-    if group is None:
-        print(f"Worker Group {WORKER_GROUP_ID} not found.")
-    else:
-        # Scale and provision the Worker Group
-        # Equivalent to 48 MB/s maximum estimated ingest rate with 21 Worker Processes
-        group.estimated_ingest_rate = EstimatedIngestRateOptionsConfigGroup.RATE48_MB_PER_SEC
-        group.provisioned = True
+    # Verify Worker Group block
+    # Fetches the Worker Group using WORKER_GROUP_ID from the user-supplied
+    # parameters block and exits if it does not exist so that scaling does 
+    # not run against a missing Worker Group.
+    worker_group_response = cribl.groups.get(id=WORKER_GROUP_ID, product=ProductsCore.STREAM)
+    if not worker_group_response.items or len(worker_group_response.items) == 0:
+        print(f"❌ Worker Group not found: {WORKER_GROUP_ID}. Create the Worker Group first.")
+        return
 
-        cribl.groups.update(
-            product=ProductsCore.STREAM,
-            id=group.id,
-            id_param=group.id,
-            name=group.name,
-            description=group.description,
-            cloud=group.cloud,
-            worker_remote_access=group.worker_remote_access,
-            is_fleet=group.is_fleet,
-            is_search=group.is_search,
-            on_prem=group.on_prem,
-            estimated_ingest_rate=group.estimated_ingest_rate,
-            provisioned=group.provisioned,
-        )
-        print(f"✅ Worker Group scaled and provisioned: {group.id}")
+    group = worker_group_response.items[0]
+    if not group or not group.id:
+        print(f"❌ Worker Group not found: {WORKER_GROUP_ID}. Create the Worker Group first.")
+        return
 
+    # Scale Worker Group block
+    # Sets estimated_ingest_rate to SCALED_ESTIMATED_INGEST_RATE from the Estimated
+    # ingest rate block and provisioned to True, then persists the Worker Group with
+    # groups.update and prints a confirmation message.
+    group.estimated_ingest_rate = SCALED_ESTIMATED_INGEST_RATE
+    group.provisioned = True
+
+    cribl.groups.update(
+        product=ProductsCore.STREAM,
+        id=group.id,
+        id_param=group.id,
+        name=group.name,
+        description=group.description,
+        cloud=group.cloud,
+        worker_remote_access=group.worker_remote_access,
+        is_fleet=group.is_fleet,
+        is_search=group.is_search,
+        on_prem=group.on_prem,
+        estimated_ingest_rate=group.estimated_ingest_rate,
+        provisioned=group.provisioned,
+    )
+    print(f"✅ Worker Group scaled and provisioned: {group.id}")
+
+    # Commit block
+    # Records a new version of the Worker Group configuration, marks that
+    # version as effective, and captures the commit ID to use in the Deploy
+    # block. Raises an exception if the API returns no commit. Otherwise, prints
+    # a confirmation message.
+    commit_response = cribl.versions.commits.create(
+        message="Commit for scale Worker Group example",
+        effective=True,
+        files=["."],
+        server_url=group_url,
+    )
+
+    if not commit_response.items or len(commit_response.items) == 0:
+        raise Exception("Failed to commit configuration changes")
+
+    version = commit_response.items[0].commit
+    print(f"✅ Committed configuration changes to the group: {group.id}, commit ID: {version}")
+
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from the
+    # Commit block) to the Cribl Stream Worker Group so that Workers load and run
+    # that version, then prints a confirmation message.
+    cribl.groups.deploy(
+        product=ProductsCore.STREAM,
+        id=group.id,
+        version=version,
+    )
+    print(f"✅ Worker Group changes deployed: {group.id}")
+
+
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
         print(f"❌ Something went wrong: {error}")
-

--- a/examples/example_onprem_commit_deploy.py
+++ b/examples/example_onprem_commit_deploy.py
@@ -1,27 +1,67 @@
 """
-Replace the placeholder values for ONPREM_SERVER_URL, ONPREM_USERNAME, and
-ONPREM_PASSWORD with your server URL and credentials. Your credentials are
-sensitive information and should be kept private.
+Commit and deploy configuration
+
+- Commits pending configuration changes for a Worker Group, then deploys the 
+commit so that Workers load it.
 
 NOTE: This example is for on-prem deployments only.
+
+Required to use this example:
+- A server URL, which is used to build the base URL for the SDK calls.
+- A username and password, which are used to authenticate the SDK calls.
+The username and password credentials are sensitive information and should
+be kept private.
+- A Worker Group with pending changes to commit and deploy.
 """
 
+# Import block
+# Imports asyncio so that the file can await the on-prem token request and
+# other asynchronous control plane calls (commit and deploy).
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports Security (Bearer token wrapper after username/password login),
+# ProductsCore for product identifiers, and other API payloads from the
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
 
-from cribl_control_plane.models import ProductsCore, Security
+from cribl_control_plane.models import (
+    ProductsCore,
+    Security,
+)
 
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, Commit block, and Deploy
+# block. Replace the placeholder values before executing this file.
 ONPREM_SERVER_URL = "http://localhost:9000"  # Replace with your server URL
 ONPREM_USERNAME = "admin"  # Replace with your username
 ONPREM_PASSWORD = "admin"  # Replace with your password
-WORKER_GROUP_ID = "your-worker-group-id"  # Use the same Worker Group ID as in previous examples
+WORKER_GROUP_ID = "your-worker-group-id"  # Replace with the Worker Group ID to commit and deploy
 
+# URL block
+# Builds the base URL and Worker Group-specific URL to use for the API requests
+# that this file makes using the ONPREM_SERVER_URL and WORKER_GROUP_ID provided in
+# the user-supplied parameters block. The Worker Group URL is used for the Commit
+# block.
 base_url = f"{ONPREM_SERVER_URL}/api/v1"
 group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your username and password, commits
+# pending configuration for the Worker Group, and deploys that version.
 async def main():
-    # Initialize Cribl client
+    # Authentication block
+    # Constructs CriblControlPlane with the base_url from the URL block and
+    # calls the on-prem authentication endpoint with the username and password
+    # from the user-supplied parameters block.
+    # Retrieves the Bearer token from the on-prem authentication endpoint
+    # response and wraps the token in Security.
+    # Reconstructs CriblControlPlane as an authenticated SDK client using the
+    # same base_url and Security (which holds the Bearer token).
     cribl = CriblControlPlane(server_url=base_url)
 
     response = await cribl.auth.tokens.get_async(
@@ -32,31 +72,42 @@ async def main():
     security = Security(bearer_auth=token)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Commit configuration changes
+    # Commit block
+    # Records a new version of the Worker Group configuration, marks that
+    # version as effective, and captures the commit ID to use in the Deploy
+    # block. Raises an exception if the API returns no commit. Otherwise, prints
+    # a confirmation message.
     commit_response = cribl.versions.commits.create(
         message="Commit for Cribl Stream example",
         effective=True,
         files=["."],
-        server_url=group_url
+        server_url=group_url,
     )
-    
+
     if not commit_response.items or len(commit_response.items) == 0:
         raise Exception("Failed to commit configuration changes")
-    
+
     version = commit_response.items[0].commit
     print(f"✅ Committed configuration changes to the group: {WORKER_GROUP_ID}, commit ID: {version}")
 
-    # Deploy configuration changes
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from the
+    # Commit block) to the Cribl Stream Worker Group so that Workers load and run
+    # that version, then prints a confirmation message.
     cribl.groups.deploy(
         product=ProductsCore.STREAM,
         id=WORKER_GROUP_ID,
-        version=version
+        version=version,
     )
     print(f"✅ Worker Group changes deployed: {WORKER_GROUP_ID}")
 
+
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
         print(f"❌ Something went wrong: {error}")
-

--- a/examples/example_onprem_create_worker_group.py
+++ b/examples/example_onprem_create_worker_group.py
@@ -1,39 +1,64 @@
 """
-On-Prem Create Worker Group Example
+Create a Worker Group
 
-This example demonstrates how to create an on-prem Worker Group in Cribl Stream.
+- Creates a new Worker Group in Cribl Stream.
 
-This example performs the following operations:
+NOTE: This example is for on-prem deployments only.
 
-1. Connects to Cribl Stream and authenticates.
-2. Verifies that a Worker Group with the specified ID does not already exist.
-3. Creates the Worker Group.
-4. Commits the configuration changes to the Worker Group.
-5. Deploys the configuration changes to the Worker Group.
-
-Prerequisites:
-- Replace the placeholder values for ONPREM_SERVER_URL, ONPREM_USERNAME, and
-  ONPREM_PASSWORD with your server URL and credentials. Your credentials are
-  sensitive information and should be kept private.
-- Replace the WORKER_GROUP_ID placeholder value with the Worker Group ID that 
-  you want to use.
+Required to use this example:
+- An Enterprise license.
+- A server URL, which is used to build the base URL for the SDK calls.
+- A username and password, which are used to authenticate the SDK calls. 
+The username and password credentials are sensitive information and should 
+be kept private.
 """
 
+# Import block
+# Imports asyncio so that the file can await the on-prem token request and 
+# other asynchronous control plane calls (Worker Group create, commit, deploy).
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane 
+# SDK package.
+#
+# Imports Security (Bearer token wrapper after username/password login), 
+# generated model types for Cribl Stream resources, ProductsCore for 
+# product identifiers, and other API payloads from the 
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
 
 from cribl_control_plane.models import ProductsCore, Security
 
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and Worker Group 
+# configuration block. Replace the placeholder values before executing 
+# this file.
 ONPREM_SERVER_URL = "http://localhost:9000"  # Replace with your server URL
 ONPREM_USERNAME = "admin"  # Replace with your username
 ONPREM_PASSWORD = "admin"  # Replace with your password
 WORKER_GROUP_ID = "your-worker-group-id"
 
+# URL block
+# Builds the base URL and Worker Group-specific URL to use for the 
+# API requests that this file makes using the ONPREM_SERVER_URL and 
+# WORKER_GROUP_ID provided in the user-supplied parameters block.
 base_url = f"{ONPREM_SERVER_URL}/api/v1"
+group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 
+# Workflow block
+# The async function that contains the full automation and runs when you 
+# execute this file. Authenticates using your username and password, 
+# creates the Worker Group, and commits and deploys the configuration.
 async def main():
-    # Initialize Cribl client
+    # Authentication block
+    # Constructs CriblControlPlane with the base_url from the URL block and 
+    # calls the on-prem authentication endpoint with the username and password 
+    # from the user-supplied parameters block. 
+    # Retrieves the Bearer token from the on-prem authentication endpoint 
+    # response and wraps the token in Security. 
+    # Reconstructs CriblControlPlane as an authenticated SDK client using the
+    # same base_url and Security (which holds the Bearer token).
     cribl = CriblControlPlane(server_url=base_url)
 
     response = await cribl.auth.tokens.get_async(
@@ -44,16 +69,15 @@ async def main():
     security = Security(bearer_auth=token)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Construct the base URL for the Worker Group
-    group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
-
-    # Verify that Worker Group doesn't already exist
+    # Create Worker Group block
+    # Checks for a Worker Group with the WORKER_GROUP_ID provided in the 
+    # user-supplied parameters block and exits if it already exists. 
+    # Otherwise, creates the Worker Group and prints a confirmation message.
     worker_group_response = cribl.groups.get(id=WORKER_GROUP_ID, product=ProductsCore.STREAM)
     if worker_group_response.items and len(worker_group_response.items) > 0:
         print(f"❌ Worker Group already exists: {WORKER_GROUP_ID}. Try a different group ID.")
         return
 
-    # Create the Worker Group
     cribl.groups.create(
         product=ProductsCore.STREAM,
         id=WORKER_GROUP_ID,
@@ -66,7 +90,11 @@ async def main():
     )
     print(f"✅ Worker Group created: {WORKER_GROUP_ID}")
 
-    # Commit configuration changes
+    # Commit block
+    # Records a new version of the Worker Group configuration, marks that 
+    # version as effective, and captures the commit ID to use in the 
+    # Deploy block. Raises an exception if the API returns no commit. 
+    # Otherwise, prints a confirmation message.
     commit_response = cribl.versions.commits.create(
         message="Commit for Cribl Stream example for creating a Worker Group",
         server_url=group_url,
@@ -79,7 +107,10 @@ async def main():
     version = commit_response.items[0].commit
     print(f"✅ Committed configuration changes to the group: {WORKER_GROUP_ID}, commit ID: {version}")
 
-    # Deploy configuration changes to the Worker Group
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from 
+    # the Commit block) to the Cribl Stream Worker Group so that Workers load 
+    # and run that version, then prints a confirmation message.
     cribl.groups.deploy(
         product=ProductsCore.STREAM,
         id=WORKER_GROUP_ID,
@@ -87,6 +118,10 @@ async def main():
     )
     print(f"✅ Worker Group changes deployed: {WORKER_GROUP_ID}")
 
+# Script entry block
+# Starts the async function main() with the standard library helper 
+# asyncio.run and prints an error message if the run fails. Runs only when you 
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())

--- a/examples/example_onprem_list_worker_groups.py
+++ b/examples/example_onprem_list_worker_groups.py
@@ -1,24 +1,61 @@
 """
-Replace the placeholder values for ONPREM_SERVER_URL, ONPREM_USERNAME, and
-ONPREM_PASSWORD with your server URL and credentials. Your credentials are
-sensitive information and should be kept private.
+List Worker Groups
+
+- Lists all Worker Group configurations for Cribl Stream.
 
 NOTE: This example is for on-prem deployments only.
+
+Required to use this example:
+- A server URL, which is used to build the base URL for the SDK calls.
+- A username and password, which are used to authenticate the SDK calls.
+The username and password credentials are sensitive information and should
+be kept private.
 """
 
+# Import block
+# Imports asyncio so that the file can await the on-prem token request and
+# other asynchronous control plane calls (listing Worker Groups).
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports Security (Bearer token wrapper after username/password login),
+# ProductsCore for product identifiers, and other API payloads from the
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
 
-from cribl_control_plane.models import ProductsCore, Security
+from cribl_control_plane.models import (
+    ProductsCore,
+    Security,
+)
 
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and List Worker Groups
+# block. Replace the placeholder values before executing this file.
 ONPREM_SERVER_URL = "http://localhost:9000"  # Replace with your server URL
 ONPREM_USERNAME = "admin"  # Replace with your username
 ONPREM_PASSWORD = "admin"  # Replace with your password
 
+# URL block
+# Builds the base URL to use for the API requests that this file makes using the
+# ONPREM_SERVER_URL provided in the user-supplied parameters block.
 base_url = f"{ONPREM_SERVER_URL}/api/v1"
 
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your username and password and lists
+# Worker Groups for Cribl Stream.
 async def main():
+    # Authentication block
+    # Constructs CriblControlPlane with the base_url from the URL block and
+    # calls the on-prem authentication endpoint with the username and password
+    # from the user-supplied parameters block.
+    # Retrieves the Bearer token from the on-prem authentication endpoint
+    # response and wraps the token in Security.
+    # Reconstructs CriblControlPlane as an authenticated SDK client using the
+    # same base_url and Security (which holds the Bearer token).
     cribl = CriblControlPlane(server_url=base_url)
 
     response = await cribl.auth.tokens.get_async(
@@ -29,7 +66,10 @@ async def main():
     security = Security(bearer_auth=token)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Retrieve and list all Worker Groups
+    # List Worker Groups block
+    # Calls groups.list for Cribl Stream (ProductsCore.STREAM). If the response
+    # includes items, prints each Worker Group configuration; otherwise prints
+    # that no Worker Groups were found.
     worker_groups_response = cribl.groups.list(product=ProductsCore.STREAM)
 
     if worker_groups_response.items:
@@ -39,9 +79,13 @@ async def main():
     else:
         print(f"❌ No Worker Groups found.")
 
+
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
         print(f"❌ Something went wrong: {error}")
-

--- a/examples/example_onprem_replicate_worker_group.py
+++ b/examples/example_onprem_replicate_worker_group.py
@@ -1,42 +1,69 @@
 """
-On-Prem Replicate Worker Group Example
+Replicate a Worker Group
 
-This example demonstrates how to replicate an on-prem Worker Group in 
-Cribl Stream.
+- Verifies that a source Worker Group exists in Cribl Stream.
+- Creates a replica Worker Group cloned from the source with the 
+same configuration.
+- Commits and deploys the replica Worker Group configuration to make it active.
 
-This example performs the following operations:
+NOTE: This example is for on-prem deployments only.
 
-1. Connects to Cribl Stream and authenticates.
-2. Verifies that the source Worker Group (SOURCE_WORKER_GROUP_ID) exists.
-3. Verifies that a Worker Group with the specified REPLICA_WORKER_GROUP_ID does
-   not already exist.
-4. Creates a new Worker Group that replicates the specified source Worker Group.
-5. Commits the configuration changes to the new Worker Group.
-6. Deploys the configuration changes to the new Worker Group.
-
-Prerequisites:
-- Replace the placeholder values for ONPREM_SERVER_URL, ONPREM_USERNAME, and
-  ONPREM_PASSWORD with your server URL and credentials. Your credentials are
-  sensitive information and should be kept private.
-- Replace the WORKER_GROUP_ID and REPLICA_WORKER_GROUP_ID placeholder values 
-  with the Worker Group IDs that you want to use.
+Required to use this example:
+- An Enterprise license.
+- A server URL, which is used to build the base URL for the SDK calls.
+- A username and password, which are used to authenticate the SDK calls.
+The username and password credentials are sensitive information and should
+be kept private.
+- An existing Worker Group to replicate.
 """
 
+# Import block
+# Imports asyncio so that the file can await the on-prem token request and
+# other asynchronous control plane calls (Worker Group replicate, commit,
+# deploy).
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports Security (Bearer token wrapper after username/password login),
+# ProductsCore for product identifiers, and other API payloads from the
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
 
 from cribl_control_plane.models import ProductsCore, Security
 
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and Replicate Worker
+# Group block. Replace the placeholder values before executing this file.
 ONPREM_SERVER_URL = "http://localhost:9000"  # Replace with your server URL
 ONPREM_USERNAME = "admin"  # Replace with your username
 ONPREM_PASSWORD = "admin"  # Replace with your password
-SOURCE_WORKER_GROUP_ID = "my-worker-group" # The id of the Worker Group to clone
-REPLICA_WORKER_GROUP_ID = "my-replica-worker-group" # The id to use for the replica Worker Group
-base_url = f"{ONPREM_SERVER_URL}/api/v1"
+SOURCE_WORKER_GROUP_ID = "my-worker-group"  # Replace with the ID of the Worker Group to clone
+REPLICA_WORKER_GROUP_ID = "my-replica-worker-group"  # Replace with the ID for the new replica Worker Group
 
-async def main() -> None:
-    # Initialize Cribl client
+# URL block
+# Builds the base URL and replica Worker Group-specific URL to use for the
+# API requests that this file makes using the ONPREM_SERVER_URL and
+# REPLICA_WORKER_GROUP_ID from the user-supplied parameters block.
+base_url = f"{ONPREM_SERVER_URL}/api/v1"
+group_url = f"{base_url}/m/{REPLICA_WORKER_GROUP_ID}"
+
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your username and password, verifies
+# the source Worker Group, creates the replica, and commits and deploys the
+# replica configuration.
+async def main():
+    # Authentication block
+    # Constructs CriblControlPlane with the base_url from the URL block and
+    # calls the on-prem authentication endpoint with the username and password
+    # from the user-supplied parameters block.
+    # Retrieves the Bearer token from the on-prem authentication endpoint
+    # response and wraps the token in Security.
+    # Reconstructs CriblControlPlane as an authenticated SDK client using the
+    # same base_url and Security (which holds the Bearer token).
     cribl = CriblControlPlane(server_url=base_url)
 
     response = await cribl.auth.tokens.get_async(
@@ -47,15 +74,20 @@ async def main() -> None:
     security = Security(bearer_auth=token)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Construct the base URL for the replica Worker Group
-    replica_group_url = f"{base_url}/m/{REPLICA_WORKER_GROUP_ID}"
-
-    # Verify that the source Worker Group exists
+    # Verify source Worker Group block
+    # Fetches the source Worker Group using SOURCE_WORKER_GROUP_ID from the
+    # user-supplied parameters block and exits if it does not exist so that 
+    # replication does not run without a valid source Worker Group.
     source_group_response = cribl.groups.get(id=SOURCE_WORKER_GROUP_ID, product=ProductsCore.STREAM)
     if not source_group_response.items or len(source_group_response.items) == 0:
         print(f"❌ Source Worker Group not found: {SOURCE_WORKER_GROUP_ID}. Create the source Worker Group first.")
         return
-    # Verify that the replica Worker Group does not exist
+
+    # Replicate Worker Group block
+    # Checks for a Worker Group with REPLICA_WORKER_GROUP_ID from the user-supplied
+    # parameters block and exits if it already exists. Otherwise, creates the
+    # replica using groups.create with source_group_id set to the source Worker
+    # Group ID, then prints a confirmation message.
     replica_group_response = cribl.groups.get(id=REPLICA_WORKER_GROUP_ID, product=ProductsCore.STREAM)
     if replica_group_response.items and len(replica_group_response.items) > 0:
         print(f"❌ Replica Worker Group already exists: {REPLICA_WORKER_GROUP_ID}. Try a different group ID.")
@@ -72,23 +104,29 @@ async def main() -> None:
         on_prem=True,
         source_group_id=SOURCE_WORKER_GROUP_ID,
     )
-
     print(f"✅ Worker Group replicated: {REPLICA_WORKER_GROUP_ID} (cloned from {SOURCE_WORKER_GROUP_ID})")
 
-    # Commit configuration changes
+    # Commit block
+    # Records a new version of the replica Worker Group configuration, marks that
+    # version as effective, and captures the commit ID to use in the Deploy
+    # block. Raises an exception if the API returns no commit. Otherwise, prints
+    # a confirmation message.
     commit_response = cribl.versions.commits.create(
         message="Commit for Cribl Stream example for replicating a Worker Group",
-        server_url=replica_group_url,
+        server_url=group_url,
         effective=True,
         files=["."],
     )
     if not commit_response.items or len(commit_response.items) == 0:
         raise Exception("Failed to commit configuration changes")
-    
+
     version = commit_response.items[0].commit
     print(f"✅ Committed configuration changes to the group: {REPLICA_WORKER_GROUP_ID}, commit ID: {version}")
 
-    # Deploy configuration changes to the Worker Group
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from the
+    # Commit block) to the Cribl Stream replica Worker Group so that Workers load
+    # and run that version, then prints a confirmation message.
     cribl.groups.deploy(
         product=ProductsCore.STREAM,
         id=REPLICA_WORKER_GROUP_ID,
@@ -96,9 +134,13 @@ async def main() -> None:
     )
     print(f"✅ Worker Group changes deployed: {REPLICA_WORKER_GROUP_ID}")
 
+
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except Exception as error:
-        message = str(error)
-        print(f"❌ Something went wrong: {message}")
+        print(f"❌ Something went wrong: {error}")

--- a/examples/example_onprem_scale_worker_group.py
+++ b/examples/example_onprem_scale_worker_group.py
@@ -1,36 +1,38 @@
 """
-On-Prem Worker Group Process Optimization Example
+Scale (Optimize) Worker Process settings
 
-This example demonstrates how to optimize Worker Process settings for an 
-existing on-prem Worker Group in Cribl Stream using the Control Plane SDK, 
-following the scaling guidelines from the Cribl documentation.
+- Verifies that an on-prem Worker Group exists in Cribl Stream.
+- Reads current system settings for the Worker Group.
+- Applies optimized Worker Process settings.
+- Updates system settings, commits, deploys, and restarts the Worker Group so
+that Workers pick up the changes.
 
-This example performs the following operations:
+NOTE: This example is for on-prem deployments only.
 
-1. Connects to an existing on-prem Worker Group.
-2. Retrieves the current system settings for the Worker Group.
-3. Optimizes Worker Process settings following the scaling documentation, 
-   assuming the Syslog Source load balancer is enabled on a Cribl Stream 
-   system with 6 physical cores hyperthreaded (12 vCPUs):
-   - Process count: -3 (to reserve two CPU cores for system/API overhead plus 
-     one for the load balancer process)
-   - Memory: 2048 MB (2 GB per Worker Process)
-   - Minimum Worker Process count: 2 (to spawn at least two Worker Processes)
-4. Updates the Worker Group's system settings with the optimized configuration.
-5. Commits the configuration changes to the Worker Group.
-6. Deploys the configuration changes to the Worker Group.
-7. Restarts the Worker Group to apply the changes.
+Required to use this example:
+- An Enterprise license.
+- A server URL, which is used to build the base URL for the SDK calls.
+- A username and password, which are used to authenticate the SDK calls.
+The username and password credentials are sensitive information and should
+be kept private.
+- An existing Worker Group to scale.
 
 The Cribl documentation provides more information about optimizing Worker Processes:
 https://docs.cribl.io/stream/scaling/#optimize-a-distributed-deployment-or-hybrid-group
-
-Prerequisites:
-- Replace the placeholder values for ONPREM_SERVER_URL, ONPREM_USERNAME, and
-  ONPREM_PASSWORD with your server URL and credentials. Your credentials are
-  sensitive information and should be kept private.
-- Replace WORKER_GROUP_ID with your actual Worker Group ID.
 """
 
+# Import block
+# Imports asyncio so that the file can await the on-prem token request and
+# other asynchronous control plane calls (settings read/update, commit, deploy,
+# restart).
+#
+# Imports CriblControlPlane as the API client from the cribl_control_plane
+# SDK package.
+#
+# Imports Security (Bearer token wrapper after username/password login),
+# ProductsCore for product identifiers, WorkersTypeSystemSettingsConf for
+# Worker Process tuning fields, and other API payloads from the
+# cribl_control_plane.models subpackage.
 import asyncio
 
 from cribl_control_plane import CriblControlPlane
@@ -41,15 +43,36 @@ from cribl_control_plane.models import (
     WorkersTypeSystemSettingsConf,
 )
 
+# User-supplied parameters block
+# Values to use in the URL block, Authentication block, and other blocks. 
+# Replace the placeholder values before executing this file.
 ONPREM_SERVER_URL = "http://localhost:9000"  # Replace with your server URL
 ONPREM_USERNAME = "admin"  # Replace with your username
 ONPREM_PASSWORD = "admin"  # Replace with your password
 WORKER_GROUP_ID = "your-worker-group-id"
 
+# URL block
+# Builds the base URL and Worker Group-specific URL to use for the API requests
+# that this file makes using the ONPREM_SERVER_URL and WORKER_GROUP_ID provided
+# in the user-supplied parameters block. The Worker Group URL is used for
+# system settings and commit calls.
 base_url = f"{ONPREM_SERVER_URL}/api/v1"
+group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
 
+# Workflow block
+# The async function that contains the full automation and runs when you
+# execute this file. Authenticates using your username and password, verifies
+# the Worker Group, reads and updates system settings for Worker Processes,
+# commits and deploys the configuration, then restarts the Worker Group.
 async def main():
-    # Initialize Cribl client
+    # Authentication block
+    # Constructs CriblControlPlane with the base_url from the URL block and
+    # calls the on-prem authentication endpoint with the username and password
+    # from the user-supplied parameters block.
+    # Retrieves the Bearer token from the on-prem authentication endpoint
+    # response and wraps the token in Security.
+    # Reconstructs CriblControlPlane as an authenticated SDK client using the
+    # same base_url and Security (which holds the Bearer token).
     cribl = CriblControlPlane(server_url=base_url)
 
     response = await cribl.auth.tokens.get_async(
@@ -60,20 +83,24 @@ async def main():
     security = Security(bearer_auth=token)
     cribl = CriblControlPlane(server_url=base_url, security=security)
 
-    # Construct the base URL for the Worker Group
-    group_url = f"{base_url}/m/{WORKER_GROUP_ID}"
-
-    # Verify that Worker Group exists
+    # Verify Worker Group block
+    # Fetches the Worker Group using WORKER_GROUP_ID from the user-supplied
+    # parameters block and exits if it does not exist so that scaling does 
+    # not run against a missing Worker Group.
     worker_group_response = cribl.groups.get(id=WORKER_GROUP_ID, product=ProductsCore.STREAM)
     if not worker_group_response.items or len(worker_group_response.items) == 0:
         print(f"⚠️ Worker Group not found: {WORKER_GROUP_ID}. Please create it first.")
         return
     print(f"✅ Found Worker Group: {WORKER_GROUP_ID}")
 
-    # Get current system settings to preserve existing configuration
+    # Get system settings block
+    # Loads the current Cribl system settings for the Worker Group using
+    # group_url from the URL block. Raises an exception if no settings row is
+    # returned. Prints the current Worker Process count, memory, and minimum
+    # settings for visibility before changes.
     current_settings = cribl.system.settings.cribl.list(server_url=group_url)
     current_conf = current_settings.items[0] if current_settings.items else None
-    
+
     if not current_conf:
         raise Exception("Failed to retrieve current system settings")
 
@@ -82,9 +109,11 @@ async def main():
     print(f"   Memory: {current_conf.workers.memory} MB")
     print(f"   Minimum Worker Processes: {current_conf.workers.minimum}")
 
-    # Configure Worker Process settings following scaling documentation
-    # Process count = -3 (six physical cores hyperthreaded for 12 vCPUs; reserves 2 cores for 
-    # system/API overhead plus 1 for the load balancer process)
+    # Optimize Worker Process settings block
+    # Builds WorkersTypeSystemSettingsConf for an example host: 
+    # Process count = -3 (six physical cores hyperthreaded for 12 vCPUs; 
+    # reserves 2 cores for system/API overhead plus 1 for the load 
+    # balancer process)
     # Memory: 2048 MB (default; 2 GB per Worker Process)
     # Minimum: 2 (spawn at least two Worker Processes)
     workers_config = WorkersTypeSystemSettingsConf(
@@ -93,8 +122,11 @@ async def main():
         minimum=2,  # Minimum number of Worker Processes to spawn
     )
 
-    # Update system settings with the optimized configuration for Worker Processes
-    # Preserve other settings from the current configuration
+    # Update system settings block
+    # Copies the current system configuration and replaces the workers
+    # section with workers_config from the optimize Worker Process settings
+    # block, then persists the merged configuration with system.settings.cribl.update
+    # using group_url from the URL block.
     updated_conf = current_conf.model_copy(update={"workers": workers_config})
     cribl.system.settings.cribl.update(
         **updated_conf.model_dump(exclude_none=False),
@@ -105,20 +137,27 @@ async def main():
     print(f"   Memory: {workers_config.memory} MB per Worker Process")
     print(f"   Minimum Worker Processes: {workers_config.minimum}")
 
-    # Commit configuration changes
+    # Commit block
+    # Records a new version of the Worker Group configuration, marks that
+    # version as effective, and captures the commit ID to use in the Deploy
+    # block. Raises an exception if the API returns no commit. Otherwise, prints
+    # a confirmation message.
     commit_response = cribl.versions.commits.create(
         message="Optimize Worker Process settings",
         effective=True,
         files=["."],
-        server_url=group_url
+        server_url=group_url,
     )
     if not commit_response.items or len(commit_response.items) == 0:
         raise Exception("Failed to commit configuration changes")
-    
+
     version = commit_response.items[0].commit
     print(f"✅ Committed configuration changes to the Worker Group: {WORKER_GROUP_ID}, commit ID: {version}")
 
-    # Deploy configuration changes to the Worker Group
+    # Deploy block
+    # Pushes the committed configuration version (using the commit ID from the
+    # Commit block) to the Cribl Stream Worker Group so that Workers load and run
+    # that version, then prints a confirmation message.
     cribl.groups.deploy(
         product=ProductsCore.STREAM,
         id=WORKER_GROUP_ID,
@@ -126,11 +165,18 @@ async def main():
     )
     print(f"✅ Worker Group changes deployed: {WORKER_GROUP_ID}")
 
-    # Restart the Worker Group to apply the changes
+    # Restart Worker Group block
+    # Triggers a restart for the Worker Group using group_url from the URL block
+    # so that Workers reload with the deployed system settings.
     print(f"\n🔄 Restarting Worker Group to apply changes...")
     cribl.system.settings.restart(server_url=group_url)
     print(f"✅ Worker Group restarted successfully")
 
+
+# Script entry block
+# Starts the async function main() with the standard library helper
+# asyncio.run and prints an error message if the run fails. Runs only when you
+# execute this file as the main script (not when another file imports it).
 if __name__ == "__main__":
     try:
         asyncio.run(main())


### PR DESCRIPTION
- Breaks the Configure Worker Groups code examples into logical blocks and adds/expands comments to provide detailed information about what each block does.
- Adds commit and deploy blocks to the Cloud examples (we will remove the separate Commit and Deploy step from the product doc).

I updated the separate Commit and Deploy example since I was updating the other examples anyway.